### PR TITLE
assign a default value to swiftbackmeup_crons

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,5 +44,7 @@ swiftbackmeup_postgresqls: {}
 #
 swiftbackmeup_mariadbs: {}
 
-
+# Set configuration for the cron module
+#
+swiftbackmeup_crons: {}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -143,5 +143,4 @@
         month={{ item.value.month | default('*') }}
         job={{ item.value.job | default('swiftbackmeup backup --mode daily') }}
         state={{ item.value.state | default('present') }}
-  when: '{{ swiftbackmeup_crons is defined }}'
   with_dict: '{{ swiftbackmeup_crons }}'


### PR DESCRIPTION
Ensure swiftbackmeup_crons is always initialized to avoid error like this one
(ansible 2.1.2):

  TASK [Spredzy.swiftbackmeup : Configure the swiftbackmeup crons (if desired)] **
  [DEPRECATION WARNING]: Skipping task due to undefined Error, in the future this
   will be a fatal error.: 'swiftbackmeup_crons' is undefined.
  This feature will be removed in a future release. Deprecation warnings can be disabled by
  setting deprecation_warnings=False in ansible.cfg.