### PR TITLE
swift: Add region variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ None.
         value: os_password
       os_tenant_name:
         value: os_tenant_name
+      os_region_name:
+        value: os_region_name
       os_auth_url:
         value: os_auth_url
 

--- a/library/swiftbackmeup_file.py
+++ b/library/swiftbackmeup_file.py
@@ -26,7 +26,7 @@ else:
 
 
 _PROPERTIES = ['name', 'type', 'os_username', 'os_password', 'os_tenant_name',
-               'os_auth_url', 'store_type', 'create_container',
+               'os_auth_url', 'os_region_name', 'store_type', 'create_container',
                'purge_container', 'swift_container', 'swift_pseudo_folder',
                'output_directory', 'clean_local_copy', 'backup_filename',
                'backup_filename_prefix', 'backup_filename_suffix',
@@ -90,6 +90,7 @@ class Item(object):
         self.os_username = module.params['os_username']
         self.os_password = module.params['os_password']
         self.os_tenant_name = module.params['os_tenant_name']
+        self.os_region_name = module.params['os_region_name']
         self.os_auth_url = module.params['os_auth_url']
         self.store_type = module.params['store_type']
         self.create_container = module.params['create_container']
@@ -181,6 +182,7 @@ def main():
             os_username=dict(required=False, type='str'),
             os_password=dict(required=False, type='str'),
             os_tenant_name=dict(required=False, type='str'),
+            os_region_name=dict(required=False, type='str'),
             os_auth_url=dict(required=False, type='str'),
             store_type=dict(required=False, type='str'),
             create_container=dict(required=False, type='str'),

--- a/library/swiftbackmeup_git.py
+++ b/library/swiftbackmeup_git.py
@@ -26,7 +26,7 @@ else:
 
 
 _PROPERTIES = ['name', 'type', 'os_username', 'os_password', 'os_tenant_name',
-               'os_auth_url', 'store_type', 'create_container',
+               'os_auth_url', 'os_region_name', 'store_type', 'create_container',
                'purge_container', 'swift_container', 'swift_pseudo_folder',
                'output_directory', 'clean_local_copy', 'backup_filename',
                'backup_filename_prefix', 'backup_filename_suffix',
@@ -104,6 +104,7 @@ class Item(object):
         self.os_username = module.params['os_username']
         self.os_password = module.params['os_password']
         self.os_tenant_name = module.params['os_tenant_name']
+        self.os_region_name = module.params['os_region_name']
         self.os_auth_url = module.params['os_auth_url']
         self.store_type = module.params['store_type']
         self.create_container = module.params['create_container']
@@ -196,6 +197,7 @@ def main():
             os_username=dict(required=False, type='str'),
             os_password=dict(required=False, type='str'),
             os_tenant_name=dict(required=False, type='str'),
+            os_region_name=dict(required=False, type='str'),
             os_auth_url=dict(required=False, type='str'),
             store_type=dict(required=False, type='str'),
             create_container=dict(required=False, type='str'),

--- a/library/swiftbackmeup_mariadb.py
+++ b/library/swiftbackmeup_mariadb.py
@@ -26,7 +26,7 @@ else:
 
 
 _PROPERTIES = ['name', 'type', 'os_username', 'os_password', 'os_tenant_name',
-               'os_auth_url', 'store_type', 'create_container',
+               'os_auth_url', 'os_region_name', 'store_type', 'create_container',
                'purge_container', 'swift_container', 'swift_pseudo_folder',
                'output_directory', 'clean_local_copy', 'backup_filename',
                'backup_filename_prefix', 'backup_filename_suffix',
@@ -89,6 +89,7 @@ class Item(object):
         self.os_username = module.params['os_username']
         self.os_password = module.params['os_password']
         self.os_tenant_name = module.params['os_tenant_name']
+        self.os_region_name = module.params['os_region_name']
         self.os_auth_url = module.params['os_auth_url']
         self.store_type = module.params['store_type']
         self.create_container = module.params['create_container']
@@ -186,6 +187,7 @@ def main():
             os_username=dict(required=False, type='str'),
             os_password=dict(required=False, type='str'),
             os_tenant_name=dict(required=False, type='str'),
+            os_region_name=dict(required=False, type='str'),
             os_auth_url=dict(required=False, type='str'),
             store_type=dict(required=False, type='str'),
             create_container=dict(required=False, type='str'),

--- a/library/swiftbackmeup_postgresql.py
+++ b/library/swiftbackmeup_postgresql.py
@@ -26,7 +26,7 @@ else:
 
 
 _PROPERTIES = ['name', 'type', 'os_username', 'os_password', 'os_tenant_name',
-               'os_auth_url', 'store_type', 'create_container',
+               'os_auth_url', 'os_region_name', 'store_type', 'create_container',
                'purge_container', 'swift_container', 'swift_pseudo_folder',
                'output_directory', 'clean_local_copy', 'backup_filename',
                'backup_filename_prefix', 'backup_filename_suffix',
@@ -90,6 +90,7 @@ class Item(object):
         self.os_username = module.params['os_username']
         self.os_password = module.params['os_password']
         self.os_tenant_name = module.params['os_tenant_name']
+        self.os_region_name = module.params['os_region_name']
         self.os_auth_url = module.params['os_auth_url']
         self.store_type = module.params['store_type']
         self.create_container = module.params['create_container']
@@ -193,6 +194,7 @@ def main():
             os_username=dict(required=False, type='str'),
             os_password=dict(required=False, type='str'),
             os_tenant_name=dict(required=False, type='str'),
+            os_region_name=dict(required=False, type='str'),
             os_auth_url=dict(required=False, type='str'),
             store_type=dict(required=False, type='str'),
             create_container=dict(required=False, type='str'),

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,7 @@
                      os_username={{ item.value.os_username | default(None) }}
                      os_password={{ item.value.os_password | default(None) }}
                      os_tenant_name={{ item.value.os_tenant_name | default(None) }}
+                     os_region_name={{ item.value.os_region_name | default(None) }}
                      os_auth_url={{ item.value.os_auth_url | default(None) }}
                      store_type={{ item.value.store_type | default(None) }}
                      create_container={{ item.value.create_container | default(None) }}
@@ -56,6 +57,7 @@
                       os_username={{ item.value.os_username | default(None) }}
                       os_password={{ item.value.os_password | default(None) }}
                       os_tenant_name={{ item.value.os_tenant_name | default(None) }}
+                      os_region_name={{ item.value.os_region_name | default(None) }}
                       os_auth_url={{ item.value.os_auth_url | default(None) }}
                       store_type={{ item.value.store_type | default(None) }}
                       create_container={{ item.value.create_container | default(None) }}
@@ -78,6 +80,7 @@
                             os_username={{ item.value.os_username | default(None) }}
                             os_password={{ item.value.os_password | default(None) }}
                             os_tenant_name={{ item.value.os_tenant_name | default(None) }}
+                            os_region_name={{ item.value.os_region_name | default(None) }}
                             os_auth_url={{ item.value.os_auth_url | default(None) }}
                             store_type={{ item.value.store_type | default(None) }}
                             create_container={{ item.value.create_container | default(None) }}
@@ -110,6 +113,7 @@
                          os_username={{ item.value.os_username | default(None) }}
                          os_password={{ item.value.os_password | default(None) }}
                          os_tenant_name={{ item.value.os_tenant_name | default(None) }}
+                         os_region_name={{ item.value.os_region_name | default(None) }}
                          os_auth_url={{ item.value.os_auth_url | default(None) }}
                          store_type={{ item.value.store_type | default(None) }}
                          create_container={{ item.value.create_container | default(None) }}


### PR DESCRIPTION
When using a public openstack cloud with multiple regions we need to
specify the region name to be sure to store the object-storage data
in the same region than the instances.

https://github.com/redhat-cip/swiftbackmeup/pull/27